### PR TITLE
Add ST- prefix to the ticket, as some client libraries expect it

### DIFF
--- a/src/main/java/org/soulwing/cas/server/service/TicketServiceBean.java
+++ b/src/main/java/org/soulwing/cas/server/service/TicketServiceBean.java
@@ -54,7 +54,7 @@ class TicketServiceBean implements TicketService {
     
     do {
       secureRandom.nextBytes(data);
-      String id = Base64.encodeBase64URLSafeString(data);
+      String id = "ST-" + Base64.encodeBase64URLSafeString(data);
       ticket = new TicketValue(id, loginContext.getUsername());
       prior = ticketCache.putIfAbsent(id, ticket);
     }

--- a/src/test/java/org/soulwing/cas/server/service/TicketServiceBeanTest.java
+++ b/src/test/java/org/soulwing/cas/server/service/TicketServiceBeanTest.java
@@ -18,12 +18,6 @@
  */
 package org.soulwing.cas.server.service;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
-
 import org.jmock.Expectations;
 import org.jmock.auto.Mock;
 import org.jmock.integration.junit4.JUnitRuleMockery;
@@ -33,6 +27,9 @@ import org.junit.Test;
 import org.soulwing.cas.server.LoginContext;
 import org.soulwing.cas.server.Ticket;
 import org.soulwing.cas.server.TicketState;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 /**
  * Unit tests for {@link TicketServiceBean}.
@@ -67,6 +64,7 @@ public class TicketServiceBeanTest {
 
     final Ticket ticket = service.issue();
     assertThat(ticket.toString(), is(not(nullValue())));
+    assertThat(ticket.toString(), startsWith("ST-"));
 
     final TicketState state = service.validate(ticket.toString());
     assertThat(state, is(not(nullValue())));


### PR DESCRIPTION
I've been using the PHP CAS library to work on a demo (don't ask why PHP 😉 ) and I noticed that the library performs a simple validation that ensures the ticket begins with `[PS]T-` ([code here](https://github.com/apereo/phpCAS/blob/20d31f010355048ec16ebb146d104421f3fc4352/source/CAS/Client.php#L1041)). There's an issue to fix it, but I figure it would be faster/easier to just tweak the ticket format on our end. This simply adds the `ST-` prefix to the ticket to make the validation happy.